### PR TITLE
add environment.yaml and suggestions for the installation instructions

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -4,6 +4,7 @@ Step by step
 - Obtain the source code. Currently only available via: ``git clone https://github.com/JanStreffing/cmpi-tool/``
 - Create a conda environment containing the neccessary libraries: ``conda env create -f environment.yaml``
 - Activate the conda environment via: ``conda activate cmpitool``
+- Install with pip in editable mode: ``pip install -e .``
 - Open the ``example.py`` and/or integrate cmpitool into your existing python script/notebook. 
 - Configure cmpitool using cmpisetup and the optional arguments for cmpitool.  
 - You can now run an analysis against CMIP6 model performance.

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,17 @@
+name: cmpitool
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - geopandas
+  - matplotlib
+  - numpy
+  - pandas>=1.0.0
+  - pip
+  - pooch
+  - python=3.9
+  - seaborn
+  - tqdm
+  - xarray
+  - pip:
+    - regionmask


### PR DESCRIPTION
Hi @JanStreffing,

@mzapponi found out that there is not an `environment.yaml` as described in the documentation. I have added it based on the dependencies defined in `setup.py` and updated the documentation for a final installation of the tool in the conda environment, via pip installation in editable mode.